### PR TITLE
Add ability to save images in folders based on their Patreon post

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ You will also need Python 3.7.3. (At least that is the version I'm using. Lower 
 
 ### Usage
 ```
-python yiff_image_scraper.py [start page] [last page] firstLink secondLink ...
+python yiff_image_scraper.py [start page] [last page] [-folders] firstLink secondLink ...
 ```
 Replace <b>firstLink</b>, <b>secondLink</b>, <b>...</b> with your own Links.<br>
 Note that every Link after the first one ist optional.
 
 Optional: You can choose at what page the scraper should start and end (Only for the first link!).
+
+Optional: If "-folders" is present, files will be placed in subfolders according to their original Patreon post.
 
 If any links are skipped you can/should find them in <b>SkippedFiles.txt</b>.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will also need Python 3.7.3. (At least that is the version I'm using. Lower 
 python yiff_image_scraper.py [start page] [last page] [-folders] firstLink secondLink ...
 ```
 Replace <b>firstLink</b>, <b>secondLink</b>, <b>...</b> with your own Links.<br>
-Note that every Link after the first one ist optional.
+Note that every Link after the first one is optional.
 
 Optional: You can choose at what page the scraper should start and end (Only for the first link!).
 

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -233,8 +233,8 @@ def downloadImages(url, urlCounter):
     #falls back on the post # provided by yiff.party if no appropriate title+date can be found
     for h in range(0, len(linkList)-1):
         # Grab the post number (this is yiff.party's numbering, not patreon's)
-        postNumber = {str(h):str(linkList[h].split("/")[5])}
-        postNumberDict.update(postNumber)
+        #postNumber = {str(h):str(linkList[h].split("/")[5])}
+        #postNumberDict.update(postNumber)
     
         #Find the location in the soup where the URL in question is located
         location = allSoup.find("a",href=linkList[h].replace("https://yiff.party",""))
@@ -253,7 +253,7 @@ def downloadImages(url, urlCounter):
     #Loops through the Image Urls amd downloads them.
     for i in range(len(linkList)-1):
         imageName = imageNameDict[str(i)]
-        imagePostNumber = postNumberDict[str(i)]
+        #imagePostNumber = postNumberDict[str(i)]
         imagePostDate = postDateDict[str(i)]
         imagePostTitle = postTitleDict[str(i)]
         postFolderName = imagePostDate + " " + imagePostTitle

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -50,7 +50,7 @@ except:
 
 # Check the third slot in the arguments for the "-folders" flag. If present, pop, decrement amountOfLinks, and set useFolders flag
 try:
-    if (sys.argv[3] == '-folders'):
+    if (sys.argv[1] == '-folders') or (sys.argv[2] == '-folders') or (sys.argv[3] == '-folders'):
         print("Sub folders will be created.")
         useFolders = True
         urlList.pop(0)

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -112,8 +112,7 @@ def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursivel
 
 def downloadImages(url, urlCounter):
     imageNameDict = {}
-    postDateDict = {}
-    postTitleDict = {}
+    postDateTitleDict = {}
     postNumberDict = {}
     linkList = []
     imgContainerUrls = []
@@ -233,30 +232,32 @@ def downloadImages(url, urlCounter):
     #falls back on the post # provided by yiff.party if no appropriate title+date can be found
     for h in range(0, len(linkList)-1):
         # Grab the post number (this is yiff.party's numbering, not patreon's)
-        #postNumber = {str(h):str(linkList[h].split("/")[5])}
-        #postNumberDict.update(postNumber)
-    
-        #Find the location in the soup where the URL in question is located
-        location = allSoup.find("a",href=linkList[h].replace("https://yiff.party",""))
-        #Search for the part of the post immediately above it that is a span with the 'post-time' class
-        timeStamp = location.find_previous("span","grey-text post-time").contents
-        trimmedTimeStamp = ''.join(timeStamp).split("T")[0]
-        trimmedTimeStamp = {str(h):trimmedTimeStamp}
-        postDateDict.update(trimmedTimeStamp)
-        #Search for the part of the post immediately above it that is a span with the 'card-title activator grey-text text-darken-4' class
-        postName = location.find_previous("span","card-title activator grey-text text-darken-4").contents
-        #Split out the post title and Remove any characters that would be illegal file names
-        CleanedPostName = ''.join(postName[0]).replace("<","-").replace(">","-").replace(":","-").replace("|","-").replace("?","-").replace("*","-").strip()
-        CleanedPostName = {str(h):CleanedPostName}
-        postTitleDict.update(CleanedPostName)
+        postNumber = {str(h):str(linkList[h].split("/")[5])}
+        
+        try:
+            #Find the location in the soup where the URL in question is located
+            location = allSoup.find("a",href=linkList[h].replace("https://yiff.party",""))
+            #Search for the part of the post immediately above it that is a span with the 'post-time' class
+            timeStamp = location.find_previous("span","grey-text post-times").contents
+            trimmedTimeStamp = ''.join(timeStamp).split("T")[0]
+            
+            #Search for the part of the post immediately above it that is a span with the 'card-title activator grey-text text-darken-4' class
+            postName = location.find_previous("span","card-title activator grey-text text-darken-4").contents
+            #Split out the post title and Remove any characters that would be illegal file names
+            CleanedPostName = ''.join(postName[0]).replace("<","-").replace(">","-").replace(":","-").replace("|","-").replace("?","-").replace("*","-").strip()
+            
+            dateTitle = {str(h):(trimmedTimeStamp + " " + CleanedPostName)}
+        #If we can't find a nice post name and date for whatever reason, fail to using the yiff-provided post number
+        except:
+            dateTitle = postNumber
 
-    #Loops through the Image Urls amd downloads them.
+        postDateTitleDict.update(dateTitle)
+
+    #Loops through the Image Urls and downloads them.
     for i in range(len(linkList)-1):
         imageName = imageNameDict[str(i)]
         #imagePostNumber = postNumberDict[str(i)]
-        imagePostDate = postDateDict[str(i)]
-        imagePostTitle = postTitleDict[str(i)]
-        postFolderName = imagePostDate + " " + imagePostTitle
+        postFolderName = postDateTitleDict[str(i)]
         urlI = linkList[i]
         print("Downloading " + imageName)           #Shows the name of the current downloading image
         downloader(urlI, imageName, patreonAuthor, postFolderName)

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -48,10 +48,10 @@ except SystemExit:
 except:
     pass
 
-# Check the third slot in the arguments for the "-folders" flag. If present, pop, decrement amountOfLinks, and set useFolders flag
+# Check the arguments for the "-folders" flag. If present, pop urlList, decrement amountOfLinks, and set useFolders flag
 try:
     if (sys.argv[1] == '-folders') or (sys.argv[2] == '-folders') or (sys.argv[3] == '-folders'):
-        print("Sub folders will be created.")
+        print("Sub folders will be created.\n")
         useFolders = True
         urlList.pop(0)
         amountOfLinks -= 1
@@ -116,7 +116,7 @@ def makeConformUrl(aList):
 def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursively tries to download the images - in the case of the site not accepting anymore requests
     global imageCounter
     try:
-        r = requests.get(myUrl, headers = {'User-Agent': userAgent}, timeout=(2,5), stream=True)
+        r = requests.get(myUrl, headers = {'User-Agent': userAgent}, timeout=(3,6), stream=True)
         if r.status_code == 200:
             #If we were passed a valid folder name, use it to make a folder for the post
             if (postFolderName != False):
@@ -132,9 +132,9 @@ def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursivel
                         f.write(chunk)
             imageCounter += 1
         else:
-            print("beep -- file skipped: " + myUrl)
+            print("Skipped (Bad Response: " + str(r.status_code) + "): " + myUrl)
     except:
-        print("Skipped: " + myUrl)
+        print("Skipped (Other Error): " + myUrl)
         missingFiles.append(myUrl)
         return
 

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -238,7 +238,7 @@ def downloadImages(url, urlCounter):
             #Find the location in the soup where the URL in question is located
             location = allSoup.find("a",href=linkList[h].replace("https://yiff.party",""))
             #Search for the part of the post immediately above it that is a span with the 'post-time' class
-            timeStamp = location.find_previous("span","grey-text post-times").contents
+            timeStamp = location.find_previous("span","grey-text post-time").contents
             trimmedTimeStamp = ''.join(timeStamp).split("T")[0]
             
             #Search for the part of the post immediately above it that is a span with the 'card-title activator grey-text text-darken-4' class

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -60,10 +60,13 @@ def setFlag(boolean):
     cLastPageFlag = boolean
 
 def sanitiseFolderName(rawFolderName):
-    #First remove all characters that are not alphanumerics or in this list: _- #!(),.
-    cleanedFolderName = "".join(x for x in rawFolderName if(x.isalnum() or x in "_- #!(),."))
-    #Then let's remove any preceding or trailing spaces or periods
-    cleanedFolderName = cleanedFolderName.strip(' .')
+    #First remove all characters that are not alphanumerics or in this list: _- #!(),.$+
+    cleanedFolderName = "".join(x for x in rawFolderName if(x.isalnum() or x in "_- #!(),.$+"))
+    #Then let's remove any preceding or trailing spaces, periods, commas
+    cleanedFolderName = cleanedFolderName.strip(' .,')
+    #If those steps have trimmed the name down to no characters, add a placeholder
+    if (len(cleanFolderName) < 1):
+        cleanedFolderName = "NA" + cleanFolderName
     return cleanedFolderName
 
 def accountForDuplicates(aDict):

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -132,9 +132,9 @@ def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursivel
                         f.write(chunk)
             imageCounter += 1
         else:
-            print("Skipped (Bad Response: " + str(r.status_code) + "): " + myUrl)
+            print(">Skipped (Bad Response: " + str(r.status_code) + "): " + myUrl)
     except:
-        print("Skipped (Other Error): " + myUrl)
+        print(">Skipped (Other Error): " + myUrl)
         missingFiles.append(myUrl)
         return
 


### PR DESCRIPTION
Hello Xaeleph!
Thank you for creating this tool.

I've added a few modifications to your script that helped it fit my use-case a little better and wanted to offer them as a pull request if you wanted to integrate them.
If they aren't to your liking, feel free to decline and I'll just maintain my fork for my use.

I've added the following:

- When the "-folders" switch is used, the script generates a folder for each post to place images
- If the "-folders" switch is not passed, the script performs the same as before
- Folders are named with the date of the original post, as well as its original title (if those can be found)
- If the proper naming cannot be found, it uses the post number Yiff.party has assigned it
- Folder names are sanitized to prevent illegal folder names
- The error message for a non-200 response was modified to show what the failing response was

I tried to avoid tampering with the structure of your work, and to limit any modifications to the bare minimum required to make the folders work consistently.

I've tested it on several creators, with a variety of combinations of start/end pages and folders and so on, and it seems to work consistently and smoothly.

See the two attached images to get an idea what the output looks like:
![folders](https://user-images.githubusercontent.com/27835519/77983906-a9401e80-72ff-11ea-9941-6b00fb445a59.PNG)
![no folders](https://user-images.githubusercontent.com/27835519/77983907-a9d8b500-72ff-11ea-92ae-d1b680d049f9.PNG)

