### PR TITLE
Ignore Existing Files/Images (Do not re-download existing)

### DIFF
--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -7,6 +7,7 @@ import platform
 amountOfLinks = len(sys.argv)-1
 urlCounter = 0
 imageCounter = 0
+skippedCounter = 0
 urlList = []
 missingFiles = []
 userAgent = "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2225.0 Safari/537.36"
@@ -115,11 +116,13 @@ def makeConformUrl(aList):
 
 def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursively tries to download the images - in the case of the site not accepting anymore requests
     global imageCounter
+    global skippedCounter
     try:
         r = requests.get(myUrl, headers = {'User-Agent': userAgent}, timeout=(30,30), stream=True)
         if r.status_code == 200:
             #If we were passed a valid folder name, use it to make a folder for the post
             if (postFolderName != False):
+                # If the folder does not already exist, make it!
                 if not os.path.isdir("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +""):
                     os.mkdir("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +"")
                 # If the file doesn't already exist, download it!
@@ -127,8 +130,10 @@ def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursivel
                     with open("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +"" + myImageName, 'wb') as f:
                         for chunk in r:
                             f.write(chunk)
+                    imageCounter += 1
                 else:
                     print(">Skipped, already exists!")
+                    skippedCounter += 1
             #IF we were passed 'FALSE' instead of a folder name, do not create a folder, but simply save in Author page
             else:
                 # If the file doesn't already exist, download it!
@@ -136,9 +141,10 @@ def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursivel
                     with open("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +"" + myImageName, 'wb') as f:
                         for chunk in r:
                             f.write(chunk)
+                    imageCounter += 1
                 else:
                     print(">Skipped, already exists!")
-            imageCounter += 1
+                    skippedCounter += 1
         else:
             # If we get a bad response, let the user know what it was
             print(">Skipped ["+myUrl+"]:\n>"+"(Error: Bad Response- " + str(r.status_code) + ")")
@@ -310,10 +316,11 @@ def downloadImages(url, urlCounter, useFolders):
         downloader(urlI, imageName, patreonAuthor, postFolderName)
 
     #Just a finishing message.
-    if imageCounter == 0:
-        print("No files downloaded. Maybe there are no files or you messed up the order of the arguments: python " + sys.argv[0] + " [start page] [last page] urls")
+    if (imageCounter == 0) and (skippedCounter == 0):
+        print("No files downloaded, and no existing files skipped. Maybe there are no files or you messed up the order of the arguments: python " + sys.argv[0] + " [start page] [last page] urls")
     else:
-        print("\nSuccessfully downloaded " + str(imageCounter) + " Images/Files!\n")
+        print("\nSkipped " + str(imageCounter) + " existing Images/Files!\n")
+        print("Successfully downloaded " + str(imageCounter) + " Images/Files!\n")
         print("============" + str(urlCounter) + "/" + str(amountOfLinks) + "===============\n")
 
     f = open("SkippedLinks.txt", "w+")

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -116,25 +116,35 @@ def makeConformUrl(aList):
 def downloader(myUrl, myImageName, myPatreonAuthor, postFolderName): #recursively tries to download the images - in the case of the site not accepting anymore requests
     global imageCounter
     try:
-        r = requests.get(myUrl, headers = {'User-Agent': userAgent}, timeout=(3,6), stream=True)
+        r = requests.get(myUrl, headers = {'User-Agent': userAgent}, timeout=(30,30), stream=True)
         if r.status_code == 200:
             #If we were passed a valid folder name, use it to make a folder for the post
             if (postFolderName != False):
                 if not os.path.isdir("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +""):
                     os.mkdir("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +"")
-                with open("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +"" + myImageName, 'wb') as f:
-                    for chunk in r:
-                        f.write(chunk)
+                # If the file doesn't already exist, download it!
+                if not os.path.isfile("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +"" + myImageName):
+                    with open("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +""+ postFolderName+ ""+ dirSep +"" + myImageName, 'wb') as f:
+                        for chunk in r:
+                            f.write(chunk)
+                else:
+                    print(">Skipped, already exists!")
             #IF we were passed 'FALSE' instead of a folder name, do not create a folder, but simply save in Author page
             else:
-                with open("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +"" + myImageName, 'wb') as f:
-                    for chunk in r:
-                        f.write(chunk)
+                # If the file doesn't already exist, download it!
+                if not os.path.isfile("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +"" + myImageName):
+                    with open("."+ dirSep +"Images"+ dirSep +"" + myPatreonAuthor + ""+ dirSep +"" + myImageName, 'wb') as f:
+                        for chunk in r:
+                            f.write(chunk)
+                else:
+                    print(">Skipped, already exists!")
             imageCounter += 1
         else:
-            print(">Skipped (Bad Response: " + str(r.status_code) + "): " + myUrl)
-    except:
-        print(">Skipped (Other Error): " + myUrl)
+            # If we get a bad response, let the user know what it was
+            print(">Skipped ["+myUrl+"]:\n>"+"(Error: Bad Response- " + str(r.status_code) + ")")
+    except Exception as errorCode:
+        #If we failed out of the download entirely, show the user the exception code
+        print(">Skipped ["+myUrl+"]:\n>"+"(Error: " + str(errorCode) + ")")
         missingFiles.append(myUrl)
         return
 
@@ -262,7 +272,7 @@ def downloadImages(url, urlCounter, useFolders):
         allSoup = bs(potOfAllSoup, "html.parser")
         for h in range(0, len(linkList)-1):
             # Grab the post number (this is yiff.party's numbering, not patreon's)
-            # May fail if the URL is not a media URL, in that case use the current loop number- this URL will likely get skipped
+            # May fail if the URL is not a media URL, in that case use the current loop number- this URL won't be downloaded anyway
             try:
                 postNumber = {str(h):str(linkList[h].split("/")[5])}
             except:

--- a/yiff_image_scraper.py
+++ b/yiff_image_scraper.py
@@ -319,8 +319,8 @@ def downloadImages(url, urlCounter, useFolders):
     if (imageCounter == 0) and (skippedCounter == 0):
         print("No files downloaded, and no existing files skipped. Maybe there are no files or you messed up the order of the arguments: python " + sys.argv[0] + " [start page] [last page] urls")
     else:
-        print("\nSkipped " + str(imageCounter) + " existing Images/Files!\n")
-        print("Successfully downloaded " + str(imageCounter) + " Images/Files!\n")
+        print("\nSuccessfully skipped " + str(skippedCounter) + " existing Images/Files!\n")
+        print("Successfully downloaded " + str(imageCounter) + " new Images/Files!\n")
         print("============" + str(urlCounter) + "/" + str(amountOfLinks) + "===============\n")
 
     f = open("SkippedLinks.txt", "w+")


### PR DESCRIPTION
The PR adds a check before each download line to determine if the file exists.
If the file exists, the a new download is not initiated, the user is notified, and skippedCounter is incremented.
![image](https://user-images.githubusercontent.com/27835519/82137321-7e098400-9806-11ea-954d-ab5ccf011700.png)
The position of imageCounter variable was adjusted slightly to only count instances where a new file was downloaded.
The message at the end of the code that previously told the user how many files were downloaded has been adjusted to also tell the user how many were skipped due to existing files.
![image](https://user-images.githubusercontent.com/27835519/82137304-5e725b80-9806-11ea-8a85-55536203fe9e.png)

This PR resolves Issue #12 
